### PR TITLE
Adjust StringFormat to match the Specification

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -203,7 +203,7 @@ pub enum IntegerFormat {
 #[serde(rename_all = "lowercase")]
 pub enum StringFormat {
     Date,
-    DateTime,
+    #[serde(rename = "date-time")] DateTime,
     Password,
     Byte,
     Binary,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -203,7 +203,8 @@ pub enum IntegerFormat {
 #[serde(rename_all = "lowercase")]
 pub enum StringFormat {
     Date,
-    #[serde(rename = "date-time")] DateTime,
+    #[serde(rename = "date-time")]
+    DateTime,
     Password,
     Byte,
     Binary,


### PR DESCRIPTION
According to the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/3205baaa834305960d0805b8905bc93936c82c22/versions/3.0.2.md#data-types), the correct format string for DateTime is `date-time`, not `datetime` which was output by this library before.