### PR TITLE
Add `value` field to `Example`

### DIFF
--- a/src/example.rs
+++ b/src/example.rs
@@ -9,10 +9,16 @@ pub struct Example {
     /// CommonMark syntax MAY be used for rich text representation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Embedded literal example. The value field and externalValue
+    /// Embedded literal example. The `value` field and `externalValue`
     /// field are mutually exclusive. To represent examples of
     /// media types that cannot naturally represented in JSON or YAML,
     /// use a string value to contain the example, escaping where necessary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+    /// A URL that points to the literal example.
+    /// This provides the capability to reference examples that cannot
+    /// easily be included in JSON or YAML documents. The `value` field and
+    /// `externalValue` field are mutually exclusive.
     #[serde(rename = "externalValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_value: Option<String>,


### PR DESCRIPTION
Per the [OpenAPI spec](https://swagger.io/specification/#exampleObject), this struct should contain an optional `value` field.