### PR TITLE
Add explode field to Parameter

### DIFF
--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -40,6 +40,8 @@ pub struct ParameterData {
     pub example: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub examples: IndexMap<String, ReferenceOr<Example>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explode: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]


### PR DESCRIPTION
From the [OpenAPIv3 spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject):

```
  When this is true, parameter values of type array or object generate
  separate parameters for each value of the array or key-value pair of
  the map. For other types of parameters this property has no effect.
  When style is form, the default value is true. For all other styles,
  the default value is false.
```