### PR TITLE
fix: rename external_documentation

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -20,6 +20,7 @@ pub struct Operation {
     pub description: Option<String>,
     /// Additional external documentation for this operation.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename(serialize = "externalDocs"))]
     pub external_documentation: Option<ExternalDocumentation>,
     /// Unique string used to identify the operation.
     /// The id MUST be unique among all operations described in the API.


### PR DESCRIPTION
based on the openAPI v3 documentation the key for external documentation should be externalDocs. https://swagger.io/specification/#openapi-object