### PR TITLE
Add support for extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ cache: cargo
 
 matrix:
   include:
-  - rust: 1.35.0
+  - rust: 1.49.0
     env: NAME=test
     script:
     - cargo test --all --verbose
-  - rust: 1.35.0
+  - rust: 1.49.0
     env: NAME=pretty
     before_script:
     - rustup component add rustfmt
     script:
     - cargo fmt -- --check
-  - rust: 1.35.0
+  - rust: 1.49.0
     env: NAME=petty
     before_script:
     - rustup component add clippy

--- a/fixtures/petstore-discriminated.yaml
+++ b/fixtures/petstore-discriminated.yaml
@@ -5,6 +5,7 @@ info:
   license:
     name: MIT
   version: 1.0.0
+  x-hash: abc123
 servers:
   - url: "http://petstore.swagger.io/v1"
 paths: {}

--- a/src/components.rs
+++ b/src/components.rs
@@ -36,4 +36,7 @@ pub struct Components {
     /// An object to hold reusable Callback Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub callbacks: IndexMap<String, ReferenceOr<Callback>>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// Contact information for the exposed API.
@@ -14,4 +15,7 @@ pub struct Contact {
     /// MUST be in the format of an email address.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/discriminator.rs
+++ b/src/discriminator.rs
@@ -17,4 +17,7 @@ pub struct Discriminator {
     /// An object to hold mappings between payload values and schema names or references.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub mapping: IndexMap<String, String>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -45,4 +45,7 @@ pub struct Encoding {
     /// body media type is not application/x-www-form-urlencoded.
     #[serde(default, skip_serializing_if = "is_false")]
     pub allow_reserved: bool,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/example.rs
+++ b/src/example.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -22,4 +23,7 @@ pub struct Example {
     #[serde(rename = "externalValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_value: Option<String>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/external_documentation.rs
+++ b/src/external_documentation.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// Allows referencing an external resource for extended documentation.
@@ -10,4 +11,7 @@ pub struct ExternalDocumentation {
     /// REQUIRED. The URL for the target documentation.
     /// Value MUST be in the format of a URL.
     pub url: String,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -34,4 +34,7 @@ pub struct Header {
     pub example: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub examples: IndexMap<String, ReferenceOr<Example>>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// The object provides metadata about the API.
@@ -25,4 +26,7 @@ pub struct Info {
     /// REQUIRED. The version of the OpenAPI document (which is distinct from
     /// the OpenAPI Specification version or the API implementation version).
     pub version: String,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/license.rs
+++ b/src/license.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// License information for the exposed API.
@@ -8,4 +9,7 @@ pub struct License {
     /// A URL to the license used for the API. MUST be in the format of a URL.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -48,4 +48,7 @@ pub struct Link {
     /// A server object to be used by the target operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server: Option<Server>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -44,4 +45,7 @@ pub struct OpenAPI {
     #[serde(rename = "externalDocs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// Describes a single API operation on a path.
@@ -65,6 +66,9 @@ pub struct Operation {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub servers: Vec<Server>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }
 
 #[cfg(test)]
@@ -83,7 +87,8 @@ mod tests {
                         let mut map = IndexMap::new();
                         map.insert(StatusCode::Code(200), ReferenceOr::ref_("test"));
                         map
-                    }
+                    },
+                    ..Default::default()
                 },
                 ..Default::default()
             },
@@ -98,7 +103,8 @@ mod tests {
                         let mut map = IndexMap::new();
                         map.insert(StatusCode::Code(666), ReferenceOr::ref_("demo"));
                         map
-                    }
+                    },
+                    ..Default::default()
                 },
                 ..Default::default()
             },
@@ -114,7 +120,8 @@ mod tests {
                         map.insert(StatusCode::Code(666), ReferenceOr::ref_("demo"));
                         map.insert(StatusCode::Code(418), ReferenceOr::ref_("demo"));
                         map
-                    }
+                    },
+                    ..Default::default()
                 },
                 ..Default::default()
             },

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -40,6 +40,9 @@ pub struct ParameterData {
     pub example: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub examples: IndexMap<String, ReferenceOr<Example>>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -39,6 +39,9 @@ pub struct PathItem {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<ReferenceOr<Parameter>>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }
 
 /// Holds the relative paths to the individual endpoints and

--- a/src/request_body.rs
+++ b/src/request_body.rs
@@ -20,4 +20,7 @@ pub struct RequestBody {
     /// request. Defaults to false.
     #[serde(default, skip_serializing_if = "is_false")]
     pub required: bool,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -54,4 +54,8 @@ pub struct Response {
     /// the naming constraints of the names for Component Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub links: IndexMap<String, ReferenceOr<Link>>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,4 +21,7 @@ pub struct Server {
     /// The value is used for substitution in the server's URL template.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variables: Option<IndexMap<String, ServerVariable>>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/server_variable.rs
+++ b/src/server_variable.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// An object representing a Server Variable
@@ -19,4 +20,7 @@ pub struct ServerVariable {
     /// variable. CommonMark syntax MAY be used
     /// for rich text representation.
     pub description: Option<String>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// Adds metadata to a single tag that is used by the
@@ -15,4 +16,7 @@ pub struct Tag {
     /// Additional external documentation for this tag.
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
+    /// Inline extensions to this object.
+    #[serde(flatten)]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -145,8 +145,14 @@ fn petstore_discriminated() {
             license: Some(License {
                 name: "MIT".to_owned(),
                 url: None,
+                ..Default::default()
             }),
             version: "1.0.0".to_owned(),
+            extensions: {
+                let mut ext = IndexMap::new();
+                ext.insert("x-hash".to_string(), serde_json::json!("abc123"));
+                ext
+            },
             ..Default::default()
         },
         servers: vec![Server {


### PR DESCRIPTION
Closes #19

This is a fairly simple approach to adding support for extensions. A more sophisticated approach could involve validation to ensure that keys in the extensions map were of form "x-.*", but that seems both low value and potentially cumbersome.

I need this for https://github.com/oxidecomputer/dropshot/pull/80
