### PR TITLE
fix: skip serializing feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_yaml = "0.8"
 indexmap = {version = "1.0", features = ["serde-1"]}
+
+[features]
+skip_serializing_defaults = []

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -65,7 +65,7 @@ pub enum Parameter {
         #[serde(default)]
         #[serde(rename = "allowReserved", skip_serializing_if = "is_false")]
         allow_reserved: bool,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "SkipSerializeIfDefault::skip")]
         style: QueryStyle,
         /// Sets the ability to pass empty-valued parameters. This is
         /// valid only for query parameters and allows sending a parameter
@@ -79,23 +79,35 @@ pub enum Parameter {
     Header {
         #[serde(flatten)]
         parameter_data: ParameterData,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "SkipSerializeIfDefault::skip")]
         style: HeaderStyle,
     },
     #[serde(rename = "path")]
     Path {
         #[serde(flatten)]
         parameter_data: ParameterData,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "SkipSerializeIfDefault::skip")]
         style: PathStyle,
     },
     #[serde(rename = "cookie")]
     Cookie {
         #[serde(flatten)]
         parameter_data: ParameterData,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "SkipSerializeIfDefault::skip")]
         style: CookieStyle,
     },
+}
+
+struct SkipSerializeIfDefault;
+impl SkipSerializeIfDefault {
+    #[cfg(feature = "skip_serializing_defaults")]
+    fn skip<D: Default + std::cmp::PartialEq>(value: &D) -> bool {
+        value == &Default::default()
+    }
+    #[cfg(not(feature = "skip_serializing_defaults"))]
+    fn skip<D: Default + std::cmp::PartialEq>(value: &D) -> bool {
+        false
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Skip serializing the parameter styles if they are at their default value
 with the feature gate skip_serializing_defaults.
Added a generic skip_serializing function which can be useful for other
 cases.