### PR TITLE
Breaking: Fix 'security' semantics between global and operation

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -28,10 +28,11 @@ pub struct OpenAPI {
     /// The list of values includes alternative security requirement objects
     /// that can be used. Only one of the security requirement objects need to
     /// be satisfied to authorize a request. Individual operations can override
-    /// this definition.
+    /// this definition. Global security settings may be overridden on a per-path
+    /// basis.
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub security: Vec<SecurityRequirement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Vec<SecurityRequirement>>,
     /// A list of tags used by the specification with additional metadata.
     /// The order of the tags can be used to reflect on their order by the
     /// parsing tools. Not all tags that are used by the Operation Object

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -58,8 +58,8 @@ pub struct Operation {
     /// authorize a request. This definition overrides any declared top-level security.
     /// To remove a top-level security declaration, an empty array can be used.
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub security: Vec<SecurityRequirement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<Vec<SecurityRequirement>>,
     /// An alternative server array to service this operation.
     /// If an alternative server object is specified at the
     /// Path Item Object or Root level, it will be overridden by this value.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
+use openapiv3::ReferenceOr::Item;
 use openapiv3::*;
 use serde_yaml;
-use openapiv3::ReferenceOr::Item;
 
 enum FileType {
     YAML,
@@ -292,22 +292,33 @@ fn global_security_removed_with_override() {
 
     // Security is overridden on one path. This path opts out of global security.
     let path_with_security_override = "/libs/granite/core/content/login.html";
-    if let Item(path_item) = openapi.paths.get(path_with_security_override)
-        .unwrap() {
-        assert!(path_item.get.as_ref().unwrap().security.is_some(),
-                "Spec removes global security with empty array.");
-        assert!(path_item.get.as_ref().unwrap().security.as_ref().unwrap().is_empty(),
-                "Spec removes global security with empty array.");
+    if let Item(path_item) = openapi.paths.get(path_with_security_override).unwrap() {
+        assert!(
+            path_item.get.as_ref().unwrap().security.is_some(),
+            "Spec removes global security with empty array."
+        );
+        assert!(
+            path_item
+                .get
+                .as_ref()
+                .unwrap()
+                .security
+                .as_ref()
+                .unwrap()
+                .is_empty(),
+            "Spec removes global security with empty array."
+        );
     } else {
         assert!(false, "Path not found")
     }
 
     // Security is NOT overridden on other paths. Callers must uses global security.
     let path_no_security_override = "/libs/granite/security/truststore.json";
-    if let Item(path_item) = openapi.paths.get(path_no_security_override)
-        .unwrap() {
-        assert!(path_item.get.as_ref().unwrap().security.is_none(),
-                "Spec does not specify security on this path.");
+    if let Item(path_item) = openapi.paths.get(path_no_security_override).unwrap() {
+        assert!(
+            path_item.get.as_ref().unwrap().security.is_none(),
+            "Spec does not specify security on this path."
+        );
     } else {
         assert!(false, "Path not found")
     }


### PR DESCRIPTION
* Change `security` properties on both top level `OpenAPI` struct, as
  well as `Operation` to be wrapped in `Option`.
* Without this change, it is impossible to tell in the deserialized
  objects whether or not `security` has been omitted or explicitly set
  to an empty array - since either value deserializes to an empty `Vec`.
* Although this is a breaking change, it is vital to correctly handle the
  OpenAPI semantics of  `Operation.security`:
  >To remove a top-level security declaration, an empty array can be used