### PR TITLE
add PathItem::iter() to iterate over non-None operations

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -44,6 +44,23 @@ pub struct PathItem {
     pub extensions: IndexMap<String, serde_json::Value>,
 }
 
+impl PathItem {
+    pub fn iter(&self) -> impl Iterator<Item = &Operation> + '_ {
+        vec![
+            &self.get,
+            &self.put,
+            &self.post,
+            &self.delete,
+            &self.options,
+            &self.head,
+            &self.patch,
+            &self.trace,
+        ]
+        .into_iter()
+        .flat_map(|o| o.iter())
+    }
+}
+
 /// Holds the relative paths to the individual endpoints and
 /// their operations. The path is appended to the URL from the
 /// Server Object in order to construct the full URL. The Paths

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -57,7 +57,7 @@ impl PathItem {
             &self.trace,
         ]
         .into_iter()
-        .flat_map(|o| o.iter())
+        .flat_map(Option::iter)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -268,8 +268,9 @@ fn test_operation_extension_docs() {
         .iter()
         .filter_map(|(_, i)| match i {
             ReferenceOr::Reference { .. } => None,
-            ReferenceOr::Item(item) => item.get.as_ref(),
+            ReferenceOr::Item(item) => Some(item),
         })
+        .flat_map(|item| item.iter())
         .flat_map(|o| o.extensions.iter().filter(|e| !e.0.starts_with("x-")))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
@glademiller would love your feedback on this. It was useful for a test I was writing and can imagine it being useful more generally. Other feedback also very welcome. Thanks, and no rush.