### PR TITLE
The spec says an enum can be a null

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -117,7 +117,7 @@ pub struct StringType {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
     #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enumeration: Vec<String>,
+    pub enumeration: Vec<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_length: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -180,10 +180,10 @@ fn petstore_discriminated() {
                                         },
                                         schema_kind: SchemaKind::Type(Type::String(StringType {
                                             enumeration: vec![
-                                                "clueless".to_owned(),
-                                                "lazy".to_owned(),
-                                                "adventurous".to_owned(),
-                                                "aggressive".to_owned(),
+                                                Some("clueless".to_owned()),
+                                                Some("lazy".to_owned()),
+                                                Some("adventurous".to_owned()),
+                                                Some("aggressive".to_owned()),
                                             ],
                                             ..Default::default()
                                         })),


### PR DESCRIPTION
This is a breaking change for anyone on older versions.

Relevant issue: https://github.com/github/rest-api-description/issues/454