### PR TITLE
array types do not always define a "type"

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -180,7 +180,8 @@ pub struct ObjectType {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ArrayType {
-    pub items: ReferenceOr<Box<Schema>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<ReferenceOr<Box<Schema>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_items: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
this leaves it up to the user to define although in the case of the
github api, they are mostly strings

Signed-off-by: Jess Frazelle <jess@oxide.computer>