### PR TITLE
add description to security scheme per spec

### DIFF
--- a/src/security_scheme.rs
+++ b/src/security_scheme.rs
@@ -13,19 +13,29 @@ pub enum SecurityScheme {
         #[serde(rename = "in")]
         location: APIKeyLocation,
         name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
     },
     #[serde(rename = "http")]
     HTTP {
         scheme: String,
         #[serde(rename = "bearerFormat")]
         bearer_format: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
     },
     #[serde(rename = "oauth2")]
-    OAuth2 { flows: OAuth2Flows },
+    OAuth2 {
+        flows: OAuth2Flows,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
     #[serde(rename = "openIdConnect")]
     OpenIDConnect {
         #[serde(rename = "openIdConnectUrl")]
         open_id_connect_url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
     },
 }
 


### PR DESCRIPTION
Adding a description field to `SecurityScheme` enum. Not sure if it's preferred to repeat the field across all variants, but anything else might be messy. 

Spec: 
[https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#securitySchemeObject](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#securitySchemeObject)