### PR TITLE
Thorough review of all components

### DIFF
--- a/fixtures/api-with-examples.yaml
+++ b/fixtures/api-with-examples.yaml
@@ -3,7 +3,10 @@ info:
   title: Simple API overview
   version: 2.0.0
 paths:
+  x-paths-extension: paths extension
   /:
+    summary: Stuff off of slash
+    description: Slash stuff
     get:
       operationId: listVersionsv2
       summary: List API versions
@@ -46,6 +49,7 @@ paths:
             300 response
           content:
             application/json: 
+              x-media-type-extension: media-type extension
               examples: 
                 foo:
                   value: |
@@ -80,6 +84,7 @@ paths:
       operationId: getVersionDetailsv2
       summary: Show API version details
       responses:
+        x-responses: responses extension
         '200':
           description: |-
             200 response

--- a/fixtures/link-example.yaml
+++ b/fixtures/link-example.yaml
@@ -175,6 +175,8 @@ components:
         username: $response.body#/author/username
         slug: $response.body#/repository/slug
         pid: $response.body#/id
+    NoParams:
+      operationId: mergePullRequest
   schemas: 
     user: 
       type: object

--- a/src/components.rs
+++ b/src/components.rs
@@ -37,6 +37,6 @@ pub struct Components {
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub callbacks: IndexMap<String, ReferenceOr<Callback>>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -16,6 +16,6 @@ pub struct Contact {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/discriminator.rs
+++ b/src/discriminator.rs
@@ -18,6 +18,6 @@ pub struct Discriminator {
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub mapping: IndexMap<String, String>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -46,6 +46,6 @@ pub struct Encoding {
     #[serde(default, skip_serializing_if = "is_false")]
     pub allow_reserved: bool,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/example.rs
+++ b/src/example.rs
@@ -24,6 +24,6 @@ pub struct Example {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_value: Option<String>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/external_documentation.rs
+++ b/src/external_documentation.rs
@@ -12,6 +12,6 @@ pub struct ExternalDocumentation {
     /// Value MUST be in the format of a URL.
     pub url: String,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -35,6 +35,6 @@ pub struct Header {
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub examples: IndexMap<String, ReferenceOr<Example>>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -27,6 +27,6 @@ pub struct Info {
     /// the OpenAPI Specification version or the API implementation version).
     pub version: String,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/license.rs
+++ b/src/license.rs
@@ -10,6 +10,6 @@ pub struct License {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -43,12 +43,12 @@ pub struct Link {
     /// to the linked operation. The parameter name can be qualified
     /// using the parameter location [{in}.]{name} for operations
     /// that use the same parameter name in different locations (e.g. path.id).
-    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub parameters: IndexMap<String, String>,
     /// A server object to be used by the target operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server: Option<Server>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -12,4 +12,7 @@ pub struct MediaType {
     pub examples: IndexMap<String, ReferenceOr<Example>>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub encoding: IndexMap<String, Encoding>,
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -47,6 +47,6 @@ pub struct OpenAPI {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -67,7 +67,7 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub servers: Vec<Server>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }
 

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -43,7 +43,7 @@ pub struct ParameterData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explode: Option<bool>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }
 

--- a/src/request_body.rs
+++ b/src/request_body.rs
@@ -21,6 +21,6 @@ pub struct RequestBody {
     #[serde(default, skip_serializing_if = "is_false")]
     pub required: bool,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,6 @@ pub struct Server {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variables: Option<IndexMap<String, ServerVariable>>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/server_variable.rs
+++ b/src/server_variable.rs
@@ -21,6 +21,6 @@ pub struct ServerVariable {
     /// for rich text representation.
     pub description: Option<String>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -17,6 +17,6 @@ pub struct Tag {
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
     /// Inline extensions to this object.
-    #[serde(flatten)]
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
     pub extensions: IndexMap<String, serde_json::Value>,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,65 @@
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use indexmap::IndexMap;
+use serde::{
+    de::{IgnoredAny, Visitor},
+    Deserialize, Deserializer,
+};
+
 #[allow(clippy::trivially_copy_pass_by_ref)] // needs to match signature for use in serde attribute
 #[inline]
 pub const fn is_false(v: &bool) -> bool {
     !(*v)
+}
+
+pub(crate) fn deserialize_extensions<'de, D>(
+    deserializer: D,
+) -> Result<IndexMap<String, serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_map(PredicateVisitor(
+        |key: &String| key.starts_with("x-"),
+        PhantomData,
+    ))
+}
+
+/// Used to deserialize IndexMap<K, V> that are flattened within other structs.
+/// This only adds keys that satisfy the given predicate.
+pub(crate) struct PredicateVisitor<F, K, V>(pub F, pub PhantomData<(K, V)>);
+
+impl<'de, F, K, V> Visitor<'de> for PredicateVisitor<F, K, V>
+where
+    F: Fn(&K) -> bool,
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
+{
+    type Value = IndexMap<K, V>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a map whose fields obey a predicate")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut ret = Self::Value::default();
+
+        loop {
+            match map.next_key::<K>() {
+                Err(_) => (),
+                Ok(None) => break,
+                Ok(Some(key)) if self.0(&key) => {
+                    let _ = ret.insert(key, map.next_value()?);
+                }
+                Ok(Some(_)) => {
+                    let _ = map.next_value::<IgnoredAny>()?;
+                }
+            }
+        }
+
+        Ok(ret)
+    }
 }

--- a/src/variant_or.rs
+++ b/src/variant_or.rs
@@ -12,7 +12,7 @@ pub enum VariantOrUnknown<T> {
 pub enum VariantOrUnknownOrEmpty<T> {
     Item(T),
     Unknown(String),
-    Empty, // @todo this should serialize as nothing
+    Empty,
 }
 
 impl<T> VariantOrUnknownOrEmpty<T> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,6 @@
 use indexmap::IndexMap;
 use newline_converter::dos2unix;
-use openapiv3::ReferenceOr::Item;
 use openapiv3::*;
-use serde_yaml;
 
 enum FileType {
     YAML,
@@ -267,6 +265,7 @@ fn test_operation_extension_docs() {
         serde_json::from_str(slack.2).expect(&format!("Could not deserialize file {}", slack.1));
     let operation_extensions = api
         .paths
+        .paths
         .iter()
         .filter_map(|(_, i)| match i {
             ReferenceOr::Reference { .. } => None,
@@ -294,7 +293,12 @@ fn global_security_removed_with_override() {
 
     // Security is overridden on one path. This path opts out of global security.
     let path_with_security_override = "/libs/granite/core/content/login.html";
-    if let Item(path_item) = openapi.paths.get(path_with_security_override).unwrap() {
+    if let ReferenceOr::Item(path_item) = openapi
+        .paths
+        .paths
+        .get(path_with_security_override)
+        .unwrap()
+    {
         assert!(
             path_item.get.as_ref().unwrap().security.is_some(),
             "Spec removes global security with empty array."
@@ -311,17 +315,19 @@ fn global_security_removed_with_override() {
             "Spec removes global security with empty array."
         );
     } else {
-        assert!(false, "Path not found")
+        panic!("Path not found")
     }
 
     // Security is NOT overridden on other paths. Callers must uses global security.
     let path_no_security_override = "/libs/granite/security/truststore.json";
-    if let Item(path_item) = openapi.paths.get(path_no_security_override).unwrap() {
+    if let ReferenceOr::Item(path_item) =
+        openapi.paths.paths.get(path_no_security_override).unwrap()
+    {
         assert!(
             path_item.get.as_ref().unwrap().security.is_none(),
             "Spec does not specify security on this path."
         );
     } else {
-        assert!(false, "Path not found")
+        panic!("Path not found")
     }
 }


### PR DESCRIPTION
- add extensions to Paths
- add summary and description to Path
- add extensions to MediaType
- add extensions to Responses
- fix Links so that they don't require parameters
- new deserialization mechanisms to ignore certain keys
This is a breaking change, in particular because of the introduction of the Paths struct

Fixes #39 

I tested this by deserializing all OpenAPI 3.0.x docs in this repo: https://github.com/APIs-guru/openapi-directory