### PR TITLE
Move serde_yaml to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ description = "This crate aims to provide data structures that represent the Ope
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-serde_yaml = "0.8"
 indexmap = {version = "1.0", features = ["serde-1"]}
 
 [dev-dependencies]
 newline-converter = "0.2.0"
+serde_yaml = "0.8"
 
 [features]
 skip_serializing_defaults = []


### PR DESCRIPTION
Currently, `serde_yaml` is only used in tests so placing it in `[dev-dependencies]` removes it from being a forced transitive dependency for users of this crate. I would suggest that this is a net positive change because:
1. Users need to specify `serde_yaml` separately in their `Cargo.toml` anyways to serialize to or deserialize from YAML
2. This crate does not re-export `serde_yaml` in any way (unlike `serde_json::Value`) so the API is unchanged