### PR TITLE
fix: do not serialize empty security scheme options

### DIFF
--- a/src/security_scheme.rs
+++ b/src/security_scheme.rs
@@ -19,7 +19,7 @@ pub enum SecurityScheme {
     #[serde(rename = "http")]
     HTTP {
         scheme: String,
-        #[serde(rename = "bearerFormat")]
+        #[serde(rename = "bearerFormat", skip_serializing_if = "Option::is_none")]
         bearer_format: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
@@ -66,12 +66,14 @@ pub enum OAuth2Flow {
     #[serde(rename_all = "camelCase")]
     Implicit {
         authorization_url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         #[serde(default)]
         scopes: IndexMap<String, String>,
     },
     #[serde(rename_all = "camelCase")]
     Password {
+        #[serde(skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         token_url: String,
         #[serde(default)]
@@ -79,6 +81,7 @@ pub enum OAuth2Flow {
     },
     #[serde(rename_all = "camelCase")]
     ClientCredentials {
+        #[serde(skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         token_url: String,
         #[serde(default)]
@@ -88,6 +91,7 @@ pub enum OAuth2Flow {
     AuthorizationCode {
         authorization_url: String,
         token_url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         refresh_url: Option<String>,
         #[serde(default)]
         scopes: IndexMap<String, String>,


### PR DESCRIPTION
Prevent the serialization of optional values in security schemes (as per the OpenAPI 3.0.x specification) into `null`/`~` JSON/YAML properties.