### PR TITLE
Add enum field to boolean types

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -68,7 +68,7 @@ pub enum Type {
     Integer(IntegerType),
     Object(ObjectType),
     Array(ArrayType),
-    Boolean {},
+    Boolean(BooleanType),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -212,6 +212,13 @@ pub struct ArrayType {
     pub max_items: Option<usize>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub unique_items: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BooleanType {
+    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
+    pub enumeration: Vec<Option<bool>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
I'm using this library with the stripe API, and they've got a few places where they use the enum field on a boolean to indicate that a field will always be either true or false.

This PR updates the types in this crate to support that.  It's a small change, but still probably counts as a breaking change, so not sure how you want to handle that?