### PR TITLE
support indexmap 2.0.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Report cargo version
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, windows-2019, macos-10.15 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openapiv3"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Glade Miller <glademiller@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -12,11 +12,11 @@ description = "This crate provides data structures that represent the OpenAPI v3
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-indexmap = {version = "1.0", features = ["serde-1"]}
+indexmap = {version = ">=1.6.1, <3.0.0", features = ["serde"]}
 
 [dev-dependencies]
-newline-converter = "0.2.0"
-serde_yaml = "0.8"
+newline-converter = "0.3.0"
+serde_yaml = "0.9"
 
 [features]
 skip_serializing_defaults = []

--- a/fixtures/petstore-discriminated.yaml
+++ b/fixtures/petstore-discriminated.yaml
@@ -1,4 +1,3 @@
----
 openapi: 3.0.0
 info:
   title: Swagger Petstore
@@ -7,39 +6,39 @@ info:
   version: 1.0.0
   x-hash: abc123
 servers:
-  - url: "http://petstore.swagger.io/v1"
+- url: http://petstore.swagger.io/v1
 paths: {}
 components:
   schemas:
     Cat:
       description: A representation of a cat
       allOf:
-        - $ref: "#/components/schemas/Pet"
-        - type: object
-          properties:
-            huntingSkill:
-              description: The measured skill for hunting
-              type: string
-              enum:
-                - clueless
-                - lazy
-                - adventurous
-                - aggressive
-          required:
-            - huntingSkill
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          huntingSkill:
+            description: The measured skill for hunting
+            type: string
+            enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+        required:
+        - huntingSkill
     Dog:
       description: A representation of a dog
       allOf:
-        - $ref: "#/components/schemas/Pet"
-        - type: object
-          properties:
-            packSize:
-              description: the size of the pack the dog is from
-              type: integer
-              format: int32
-              minimum: 0
-          required:
-            - packSize
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          packSize:
+            description: the size of the pack the dog is from
+            type: integer
+            format: int32
+            minimum: 0
+        required:
+        - packSize
     Pet:
       discriminator:
         propertyName: petType
@@ -50,5 +49,5 @@ components:
         petType:
           type: string
       required:
-        - name
-        - petType
+      - name
+      - petType


### PR DESCRIPTION
support indexmap@2.0.0 by bumping the minimum version to indexmap@1.6.1 which is when the `serde-1` feature became an alias for `serde`. We can (currently) support >1.6.1 inclusive of 2.0.0 and (presumably) at least up to <3.0.0. This PR also updates some dated dev-dependencies.