### PR TITLE
fix(object-type): add oneof support

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -199,6 +199,8 @@ pub struct ObjectType {
     pub min_properties: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_properties: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub one_of: Option<Vec<ReferenceOr<ObjectType>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Adds support for `oneOf` in `ObjectType`.

Resolves: #64 