### PR TITLE
Various fixes to get ready for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2.0.0-rc.0 (2023-10-21)
+
+- Bump `indexmap` dependency to 2.0.0
+- Add `enum` field to boolean schema
+- Add `callbacks` to `Operation` type (out of conformance with spec)
+- Fix handling of subschemas with typed Schema objects
+- Fixes to SecuritySchema handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "openapiv3"
-version = "1.0.3"
+version = "2.0.0-rc.0"
 authors = ["Glade Miller <glademiller@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT/Apache-2.0"
 keywords = ["openapi", "v3"]
 homepage = "https://github.com/glademiller/openapiv3"
@@ -10,9 +10,9 @@ repository = "https://github.com/glademiller/openapiv3"
 description = "This crate provides data structures that represent the OpenAPI v3.0.x specification easily deserializable with serde."
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-indexmap = {version = ">=1.6.1, <3.0.0", features = ["serde"]}
+indexmap = { version = "2.0.0", features = ["serde"] }
 
 [dev-dependencies]
 newline-converter = "0.3.0"

--- a/src/components.rs
+++ b/src/components.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Components {
-    /// An object to hold reusable Security Scheme Objects.
+    /// An object to hold reusable Schema Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub security_schemes: IndexMap<String, ReferenceOr<SecurityScheme>>,
+    pub schemas: IndexMap<String, ReferenceOr<Schema>>,
     /// An object to hold reusable Response Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub responses: IndexMap<String, ReferenceOr<Response>>,
@@ -27,9 +27,9 @@ pub struct Components {
     /// An object to hold reusable Header Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub headers: IndexMap<String, ReferenceOr<Header>>,
-    /// An object to hold reusable Schema Objects.
+    /// An object to hold reusable Security Scheme Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub schemas: IndexMap<String, ReferenceOr<Schema>>,
+    pub security_schemes: IndexMap<String, ReferenceOr<SecurityScheme>>,
     /// An object to hold reusable Link Objects.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub links: IndexMap<String, ReferenceOr<Link>>,

--- a/src/example.rs
+++ b/src/example.rs
@@ -20,8 +20,7 @@ pub struct Example {
     /// This provides the capability to reference examples that cannot
     /// easily be included in JSON or YAML documents. The `value` field and
     /// `externalValue` field are mutually exclusive.
-    #[serde(rename = "externalValue")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "externalValue", skip_serializing_if = "Option::is_none")]
     pub external_value: Option<String>,
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -16,8 +16,7 @@ pub struct OpenAPI {
     /// An array of Server Objects, which provide connectivity information to a
     /// target server. If the servers property is not provided, or is an empty
     /// array, the default value would be a Server Object with a url value of /.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub servers: Vec<Server>,
     /// REQUIRED. The available paths and operations for the API.
     pub paths: Paths,
@@ -30,8 +29,7 @@ pub struct OpenAPI {
     /// be satisfied to authorize a request. Individual operations can override
     /// this definition. Global security settings may be overridden on a per-path
     /// basis.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security: Option<Vec<SecurityRequirement>>,
     /// A list of tags used by the specification with additional metadata.
     /// The order of the tags can be used to reflect on their order by the
@@ -39,12 +37,10 @@ pub struct OpenAPI {
     /// must be declared. The tags that are not declared MAY be organized
     /// randomly or based on the tool's logic. Each tag name in the list
     /// MUST be unique.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<Tag>,
     /// Additional external documentation.
-    #[serde(rename = "externalDocs")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -9,8 +9,7 @@ pub struct Operation {
     /// A list of tags for API documentation control.
     /// Tags can be used for logical grouping of operations
     /// by resources or any other qualifier.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     /// A short summary of what the operation does.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -36,8 +35,7 @@ pub struct Operation {
     /// parameter is defined by a combination of a name and location.
     /// The list can use the Reference Object to link to parameters
     /// that are defined at the OpenAPI Object's components/parameters.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<ReferenceOr<Parameter>>,
     /// The request body applicable for this operation.
     /// The requestBody is only supported in HTTP methods
@@ -49,6 +47,12 @@ pub struct Operation {
     /// REQUIRED. The list of possible responses as they are returned
     /// from executing this operation.
     pub responses: Responses,
+    /// A map of possible out-of band callbacks related to the parent
+    /// operation. The key is a unique identifier for the Callback Object. Each
+    /// value in the map is a Callback Object that describes a request that may
+    /// be initiated by the API provider and the expected responses.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub callbacks: IndexMap<String, Callback>,
     /// Declares this operation to be deprecated.Default value is false.
     #[serde(default, skip_serializing_if = "is_false")]
     pub deprecated: bool,
@@ -57,14 +61,12 @@ pub struct Operation {
     /// be used. Only one of the security requirement objects need to be satisfied to
     /// authorize a request. This definition overrides any declared top-level security.
     /// To remove a top-level security declaration, an empty array can be used.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security: Option<Vec<SecurityRequirement>>,
     /// An alternative server array to service this operation.
     /// If an alternative server object is specified at the
     /// Path Item Object or Root level, it will be overridden by this value.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub servers: Vec<Server>,
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -45,8 +45,7 @@ pub struct PathItem {
     /// A unique parameter is defined by a combination of a name and location.
     /// The list can use the Reference Object to link to parameters that
     /// are defined at the OpenAPI Object's components/parameters.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<ReferenceOr<Parameter>>,
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]

--- a/src/security_scheme.rs
+++ b/src/security_scheme.rs
@@ -5,37 +5,72 @@ use serde::{Deserialize, Serialize};
 /// Supported schemes are HTTP authentication, an API key (either as a
 /// header or as a query parameter), OAuth2's common flows (implicit, password,
 /// application and access code) as defined in RFC6749, and OpenID Connect Discovery.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum SecurityScheme {
     #[serde(rename = "apiKey")]
     APIKey {
+        /// The location of the API key. Valid values are "query", "header" or
+        /// "cookie".
         #[serde(rename = "in")]
         location: APIKeyLocation,
+        /// The name of the header, query or cookie parameter to be used.
         name: String,
+        /// A short description for security scheme. CommonMark syntax MAY be
+        /// used for rich text representation.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+
+        /// Inline extensions to this object.
+        #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+        extensions: IndexMap<String, serde_json::Value>,
     },
     #[serde(rename = "http")]
     HTTP {
+        /// The name of the HTTP Authorization scheme to be used in the
+        /// Authorization header as defined in RFC7235. The values used SHOULD
+        /// be registered in the IANA Authentication Scheme registry.
         scheme: String,
         #[serde(rename = "bearerFormat", skip_serializing_if = "Option::is_none")]
         bearer_format: Option<String>,
+        /// A short description for security scheme. CommonMark syntax MAY be
+        /// used for rich text representation.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+
+        /// Inline extensions to this object.
+        #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+        extensions: IndexMap<String, serde_json::Value>,
     },
     #[serde(rename = "oauth2")]
     OAuth2 {
+        /// An object containing configuration information for the flow types
+        /// supported.
         flows: OAuth2Flows,
+        /// A short description for security scheme. CommonMark syntax MAY be
+        /// used for rich text representation.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+
+        /// Inline extensions to this object.
+        #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+        extensions: IndexMap<String, serde_json::Value>,
     },
     #[serde(rename = "openIdConnect")]
     OpenIDConnect {
+        /// OpenId Connect URL to discover OAuth2 configuration values. This
+        /// MUST be in the form of a URL.
         #[serde(rename = "openIdConnectUrl")]
         open_id_connect_url: String,
+        /// A short description for security scheme. CommonMark syntax MAY be
+        /// used for rich text representation.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+
+        /// Inline extensions to this object.
+        #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+        extensions: IndexMap<String, serde_json::Value>,
     },
 }
 
@@ -50,50 +85,121 @@ pub enum APIKeyLocation {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct OAuth2Flows {
-    #[serde(flatten)]
-    pub implicit: Option<OAuth2Flow>,
-    #[serde(flatten)]
-    pub password: Option<OAuth2Flow>,
-    #[serde(flatten)]
-    pub client_credentials: Option<OAuth2Flow>,
-    #[serde(flatten)]
-    pub authorization_code: Option<OAuth2Flow>,
+    /// Configuration for the OAuth Implicit flow
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implicit: Option<ImplicitOAuth2Flow>,
+    /// Configuration for the OAuth Resource Owner Password flow
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<PasswordOAuth2Flow>,
+    /// Configuration for the OAuth Client Credentials flow. Previously called
+    /// application in OpenAPI 2.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_credentials: Option<ClientCredentialsOAuth2Flow>,
+    /// Configuration for the OAuth Authorization Code flow. Previously called
+    /// accessCode in OpenAPI 2.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_code: Option<AuthorizationCodeOAuth2Flow>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImplicitOAuth2Flow {
+    /// The authorization URL to be used for this flow. This MUST be in the
+    /// form of a URL.
+    authorization_url: String,
+    /// The URL to be used for obtaining refresh tokens. This MUST be in the
+    /// form of a URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_url: Option<String>,
+    /// The available scopes for the OAuth2 security scheme. A map between the
+    /// scope name and a short description for it. The map MAY be empty.
+    scopes: IndexMap<String, String>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub enum OAuth2Flow {
-    #[serde(rename_all = "camelCase")]
-    Implicit {
-        authorization_url: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        refresh_url: Option<String>,
-        #[serde(default)]
-        scopes: IndexMap<String, String>,
-    },
-    #[serde(rename_all = "camelCase")]
-    Password {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        refresh_url: Option<String>,
-        token_url: String,
-        #[serde(default)]
-        scopes: IndexMap<String, String>,
-    },
-    #[serde(rename_all = "camelCase")]
-    ClientCredentials {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        refresh_url: Option<String>,
-        token_url: String,
-        #[serde(default)]
-        scopes: IndexMap<String, String>,
-    },
-    #[serde(rename_all = "camelCase")]
-    AuthorizationCode {
-        authorization_url: String,
-        token_url: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        refresh_url: Option<String>,
-        #[serde(default)]
-        scopes: IndexMap<String, String>,
-    },
+pub struct PasswordOAuth2Flow {
+    /// The URL to be used for obtaining refresh tokens. This MUST be in the
+    /// form of a URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_url: Option<String>,
+    /// The token URL to be used for this flow. This MUST be in the form of a
+    /// URL.
+    token_url: String,
+    /// The available scopes for the OAuth2 security scheme. A map between the
+    /// scope name and a short description for it. The map MAY be empty.
+    scopes: IndexMap<String, String>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCredentialsOAuth2Flow {
+    /// The URL to be used for obtaining refresh tokens. This MUST be in the
+    /// form of a URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_url: Option<String>,
+    /// The token URL to be used for this flow. This MUST be in the form of a
+    /// URL.
+    token_url: String,
+    /// The available scopes for the OAuth2 security scheme. A map between the
+    /// scope name and a short description for it. The map MAY be empty.
+    scopes: IndexMap<String, String>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationCodeOAuth2Flow {
+    /// The authorization URL to be used for this flow. This MUST be in the
+    /// form of a URL.
+    authorization_url: String,
+    /// The token URL to be used for this flow. This MUST be in the form of a
+    /// URL.
+    token_url: String,
+    /// The URL to be used for obtaining refresh tokens. This MUST be in the
+    /// form of a URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_url: Option<String>,
+    /// The available scopes for the OAuth2 security scheme. A map between the
+    /// scope name and a short description for it. The map MAY be empty.
+    scopes: IndexMap<String, String>,
+
+    /// Inline extensions to this object.
+    #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
+    pub extensions: IndexMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{OpenAPI, ReferenceOr, SecurityScheme};
+
+    #[test]
+    fn test_slack_auth() {
+        let openapi: OpenAPI =
+            serde_json::from_reader(std::fs::File::open("fixtures/slack.json").unwrap()).unwrap();
+
+        assert!(matches!(
+            openapi
+                .components
+                .as_ref()
+                .unwrap()
+                .security_schemes
+                .get("slackAuth")
+                .unwrap(),
+            ReferenceOr::Item(SecurityScheme::OAuth2 { .. })
+        ));
+    }
 }

--- a/src/server_variable.rs
+++ b/src/server_variable.rs
@@ -7,9 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct ServerVariable {
     /// An enumeration of string values to be
     /// used if the substitution options are from a limited set.
-    #[serde(rename = "enum")]
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, rename = "enum", skip_serializing_if = "Vec::is_empty")]
     pub enumeration: Vec<String>,
     /// REQUIRED. The default value to use for substitution,
     /// and to send, if an alternate value is not supplied.

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -36,7 +36,7 @@ impl<'de> Deserialize<'de> for StatusCode {
             where
                 E: de::Error,
             {
-                if value >= 100 && value < 1000 {
+                if (100..1000).contains(&value) {
                     Ok(StatusCode::Code(value as u16))
                 } else {
                     Err(E::invalid_value(Unexpected::Signed(value), &self))
@@ -47,7 +47,7 @@ impl<'de> Deserialize<'de> for StatusCode {
             where
                 E: de::Error,
             {
-                if value >= 100 && value < 1000 {
+                if (100..1000).contains(&value) {
                     Ok(StatusCode::Code(value as u16))
                 } else {
                     Err(E::invalid_value(Unexpected::Unsigned(value), &self))

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_fun_call)]
+
 use indexmap::IndexMap;
 use newline_converter::dos2unix;
 use openapiv3::*;
@@ -286,7 +288,7 @@ fn test_operation_extension_docs() {
 #[test]
 fn global_security_removed_with_override() {
     let openapi: OpenAPI = serde_yaml::from_str(include_str!("../fixtures/adobe_aem.yaml"))
-        .expect(&format!("Could not deserialize adobe_aem.yaml"));
+        .expect("Could not deserialize adobe_aem.yaml");
 
     // Global security is set
     assert!(openapi.security.is_some());


### PR DESCRIPTION
- update indexmap dep to 2.0.0
- reorder Components to match spec
- coalesce serde pragmas
- add callbacks to Operation
- fix deserialization of subschemas with typed schemas

Fixes #77, #66, #65, #64, #61.