### PR TITLE
fix(oauth2flow): mark missing fields pub

### DIFF
--- a/src/security_scheme.rs
+++ b/src/security_scheme.rs
@@ -107,14 +107,14 @@ pub struct OAuth2Flows {
 pub struct ImplicitOAuth2Flow {
     /// The authorization URL to be used for this flow. This MUST be in the
     /// form of a URL.
-    authorization_url: String,
+    pub authorization_url: String,
     /// The URL to be used for obtaining refresh tokens. This MUST be in the
     /// form of a URL.
     #[serde(skip_serializing_if = "Option::is_none")]
-    refresh_url: Option<String>,
+    pub refresh_url: Option<String>,
     /// The available scopes for the OAuth2 security scheme. A map between the
     /// scope name and a short description for it. The map MAY be empty.
-    scopes: IndexMap<String, String>,
+    pub scopes: IndexMap<String, String>,
 
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
@@ -127,13 +127,13 @@ pub struct PasswordOAuth2Flow {
     /// The URL to be used for obtaining refresh tokens. This MUST be in the
     /// form of a URL.
     #[serde(skip_serializing_if = "Option::is_none")]
-    refresh_url: Option<String>,
+    pub refresh_url: Option<String>,
     /// The token URL to be used for this flow. This MUST be in the form of a
     /// URL.
-    token_url: String,
+    pub token_url: String,
     /// The available scopes for the OAuth2 security scheme. A map between the
     /// scope name and a short description for it. The map MAY be empty.
-    scopes: IndexMap<String, String>,
+    pub scopes: IndexMap<String, String>,
 
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
@@ -145,13 +145,13 @@ pub struct ClientCredentialsOAuth2Flow {
     /// The URL to be used for obtaining refresh tokens. This MUST be in the
     /// form of a URL.
     #[serde(skip_serializing_if = "Option::is_none")]
-    refresh_url: Option<String>,
+    pub refresh_url: Option<String>,
     /// The token URL to be used for this flow. This MUST be in the form of a
     /// URL.
-    token_url: String,
+    pub token_url: String,
     /// The available scopes for the OAuth2 security scheme. A map between the
     /// scope name and a short description for it. The map MAY be empty.
-    scopes: IndexMap<String, String>,
+    pub scopes: IndexMap<String, String>,
 
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]
@@ -163,17 +163,17 @@ pub struct ClientCredentialsOAuth2Flow {
 pub struct AuthorizationCodeOAuth2Flow {
     /// The authorization URL to be used for this flow. This MUST be in the
     /// form of a URL.
-    authorization_url: String,
+    pub authorization_url: String,
     /// The token URL to be used for this flow. This MUST be in the form of a
     /// URL.
-    token_url: String,
+    pub token_url: String,
     /// The URL to be used for obtaining refresh tokens. This MUST be in the
     /// form of a URL.
     #[serde(skip_serializing_if = "Option::is_none")]
-    refresh_url: Option<String>,
+    pub refresh_url: Option<String>,
     /// The available scopes for the OAuth2 security scheme. A map between the
     /// scope name and a short description for it. The map MAY be empty.
-    scopes: IndexMap<String, String>,
+    pub scopes: IndexMap<String, String>,
 
     /// Inline extensions to this object.
     #[serde(flatten, deserialize_with = "crate::util::deserialize_extensions")]


### PR DESCRIPTION
Previously they were part of enum, now they have to be marked explicitly as pub.