### PR TITLE
fix regression in #88 where ReferenceOr<T> lost property order

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -12,8 +12,16 @@ pub enum ReferenceOr<T> {
 
 // We implement Deserialize by hand in order to provide a useful error message.
 // The derived error is typically aggravating: "data did not match any variant
-// of untagged enum ReferenceOr". Instead, we deserialize to a Value, look for
-// $ref, and otherwise return the response from T::deserialize.
+// of untagged enum ReferenceOr". Instead, we deserialize to an enum that
+// includes a third variant that covers any data; for that variant, we parse
+// again and respond with that error.
+//
+// The generated code for Deserialize with an untagged enum first deserializes
+// into an intermediate form. Unlike serde_json::Value, for example, it uses a
+// type that preserves order (it is, unfortunately, not part of the public
+// interface to serde). The implementation below loses object property order
+// in the failure case... but it's the failure case so we don't particularly
+// care.
 impl<'de, T> Deserialize<'de> for ReferenceOr<T>
 where
     T: Deserialize<'de>,
@@ -22,24 +30,30 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_json::Value::deserialize(deserializer)?;
-
-        fn to_ref<S>(value: &serde_json::Value) -> Option<ReferenceOr<S>> {
-            let obj = value.as_object()?;
-            if obj.len() != 1 {
-                return None;
-            }
-            let ref_val = obj.get("$ref")?;
-            let reference = ref_val.as_str()?.to_string();
-            Some(ReferenceOr::Reference { reference })
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RefOrInner<TT> {
+            Reference {
+                #[serde(rename = "$ref")]
+                reference: String,
+            },
+            Item(TT),
+            Fail(serde_json::Value),
         }
 
-        if let Some(r) = to_ref(&value) {
-            Ok(r)
-        } else {
-            use serde::de::Error;
-            let item = T::deserialize(value).map_err(D::Error::custom)?;
-            Ok(Self::Item(item))
+        let inner = RefOrInner::<T>::deserialize(deserializer)?;
+
+        match inner {
+            RefOrInner::Reference { reference } => Ok(ReferenceOr::Reference { reference }),
+            RefOrInner::Item(item) => Ok(ReferenceOr::Item(item)),
+
+            // We know this will fail. It's inefficient in that we try (and
+            // fail) T::deserialize twice, but it allows us to produce a better
+            // error message.
+            RefOrInner::Fail(value) => Err(T::deserialize(value)
+                .map_err(<D::Error as serde::de::Error>::custom)
+                .err()
+                .expect("somehow this parsed successfully the second time")),
         }
     }
 }
@@ -112,6 +126,8 @@ impl<T> ReferenceOr<Box<T>> {
 mod tests {
     use serde_json::json;
 
+    use crate::{ReferenceOr, Schema, SchemaKind, Type};
+
     #[test]
     fn test_bad_responses() {
         // Note: missing the "description" field
@@ -134,5 +150,32 @@ mod tests {
                 "unhelpful error: {e}"
             ),
         }
+    }
+
+    #[test]
+    fn test_ref_or_order() {
+        let value = r#"
+        {
+            "type": "object",
+            "properties": {
+                "z": {},
+                "a": {},
+                "b": {}
+            }
+        }
+        "#;
+
+        let obj = serde_json::from_str::<ReferenceOr<Schema>>(value).unwrap();
+
+        let ReferenceOr::Item(obj) = obj else {
+            panic!()
+        };
+
+        let SchemaKind::Type(Type::Object(obj)) = obj.schema_kind else {
+            panic!()
+        };
+
+        let props = obj.properties.keys().collect::<Vec<_>>();
+        assert_eq!(props.as_slice(), ["z", "a", "b"]);
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -178,4 +178,23 @@ mod tests {
         let props = obj.properties.keys().collect::<Vec<_>>();
         assert_eq!(props.as_slice(), ["z", "a", "b"]);
     }
+
+    #[test]
+    fn test_ref_and() {
+        // Note: missing the "description" field
+        let value = json!({
+            "description": "this is ignored",
+            "$ref": "#/foo/bar"
+        });
+
+        let ref_or_schema = serde_json::from_value::<ReferenceOr<Schema>>(value);
+
+        match ref_or_schema {
+            // Expected case
+            Ok(ReferenceOr::Reference { .. }) => (),
+
+            Ok(ReferenceOr::Item(_)) => panic!("parsed as item"),
+            Err(e) => panic!("failed to parse: {e}"),
+        }
+    }
 }


### PR DESCRIPTION
Closes #90, #91 

Note #88 also regressed parsing of objects with a `$ref` field alongside other fields.