### PR TITLE
feat: added resolve feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde_yaml = "0.9"
 
 [features]
 skip_serializing_defaults = []
+resolve = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ serde_yaml = "0.9"
 [features]
 skip_serializing_defaults = []
 resolve = []
+
+[[test]]
+name = "integration_tests"
+path = "tests/test.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ mod parameter;
 mod paths;
 mod reference;
 mod request_body;
+#[cfg(feature = "resolve")]
+mod resolve;
 mod responses;
 mod schema;
 mod security_requirement;
@@ -45,6 +47,8 @@ pub use self::parameter::*;
 pub use self::paths::*;
 pub use self::reference::*;
 pub use self::request_body::*;
+#[cfg(feature = "resolve")]
+pub use self::resolve::*;
 pub use self::responses::*;
 pub use self::schema::*;
 pub use self::security_requirement::*;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,216 @@
+use indexmap::IndexMap;
+
+use crate::*;
+
+pub trait Resolve<T> {
+    fn resolve<'a>(&'a self, path: &str) -> Option<&'a T>;
+}
+
+pub trait ResolveWithOpenAPI<T> {
+    fn resolve<'a>(&'a self, openapi: &'a OpenAPI, path: &str) -> Option<&'a T>;
+}
+
+impl<T> ReferenceOr<T>
+where
+    OpenAPI: Resolve<T>,
+{
+    pub fn resolve<'a>(&'a self, openapi: &'a OpenAPI) -> Option<&'a T> {
+        match self {
+            ReferenceOr::Reference { reference } => openapi.resolve(reference),
+            ReferenceOr::Item(item) => Some(item),
+        }
+    }
+}
+
+// Macros
+macro_rules! resolve_with_openapi {
+    ($ty:ty, $property_name:ident, $resolve_type:ty) => {
+        impl ResolveWithOpenAPI<$resolve_type> for $ty {
+            fn resolve<'a>(
+                &'a self,
+                openapi: &'a OpenAPI,
+                path: &str,
+            ) -> Option<&'a $resolve_type> {
+                let (root_path, sub_path) = path.split_once('/')?;
+
+                match root_path {
+                    stringify!($property_name) => self.$property_name.resolve(openapi, sub_path),
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+macro_rules! resolve_root_optional {
+    ($property_name:ident, $type:ty) => {
+        impl Resolve<$type> for OpenAPI {
+            fn resolve<'a>(&'a self, path: &str) -> Option<&'a $type> {
+                let path = path.strip_prefix("#/")?;
+                let (root_path, sub_path) = path.split_once('/')?;
+
+                match root_path {
+                    stringify!($property_name) => {
+                        self.$property_name.as_ref()?.resolve(self, sub_path)
+                    }
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+macro_rules! resolve_with_openapi_index_map {
+    ($ty:ty) => {
+        impl ResolveWithOpenAPI<$ty> for IndexMap<String, ReferenceOr<$ty>> {
+            fn resolve<'a>(&'a self, openapi: &'a OpenAPI, path: &str) -> Option<&'a $ty> {
+                match self.get(path)? {
+                    ReferenceOr::Reference { reference } => openapi.resolve(reference),
+                    ReferenceOr::Item(item) => Some(item),
+                }
+            }
+        }
+    };
+}
+
+// Implement resolve for OpenAPI
+resolve_root_optional!(components, Callback);
+resolve_root_optional!(components, Example);
+resolve_root_optional!(components, Header);
+resolve_root_optional!(components, Link);
+resolve_root_optional!(components, Parameter);
+resolve_root_optional!(components, RequestBody);
+resolve_root_optional!(components, Response);
+resolve_root_optional!(components, Schema);
+resolve_root_optional!(components, SecurityScheme);
+
+// Implement resolve for Components
+resolve_with_openapi!(Components, callbacks, Callback);
+resolve_with_openapi!(Components, examples, Example);
+resolve_with_openapi!(Components, headers, Header);
+resolve_with_openapi!(Components, links, Link);
+resolve_with_openapi!(Components, parameters, Parameter);
+resolve_with_openapi!(Components, request_bodies, RequestBody);
+resolve_with_openapi!(Components, responses, Response);
+resolve_with_openapi!(Components, schemas, Schema);
+resolve_with_openapi!(Components, security_schemes, SecurityScheme);
+
+// Implement resolve for IndexMap
+resolve_with_openapi_index_map!(Callback);
+resolve_with_openapi_index_map!(Example);
+resolve_with_openapi_index_map!(Header);
+resolve_with_openapi_index_map!(Link);
+resolve_with_openapi_index_map!(Parameter);
+resolve_with_openapi_index_map!(RequestBody);
+resolve_with_openapi_index_map!(Response);
+resolve_with_openapi_index_map!(Schema);
+resolve_with_openapi_index_map!(SecurityScheme);
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_index_map_schema() {
+        let openapi = OpenAPI {
+            paths: Paths {
+                paths: IndexMap::from([(
+                    "/".to_string(),
+                    ReferenceOr::Item(PathItem {
+                        get: Some(Operation {
+                            responses: Responses {
+                                responses: IndexMap::from([(
+                                    StatusCode::Code(200),
+                                    ReferenceOr::Reference {
+                                        reference: "#/components/responses/response_1".to_string(),
+                                    },
+                                )]),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                )]),
+                extensions: IndexMap::new(),
+            },
+            components: Some(Components {
+                responses: IndexMap::from([
+                    (
+                        "response_1".to_string(),
+                        ReferenceOr::Reference {
+                            reference: "#/components/responses/response_2".to_string(),
+                        },
+                    ),
+                    (
+                        "response_2".to_string(),
+                        ReferenceOr::Item(Response {
+                            content: IndexMap::from([(
+                                "application/json".to_string(),
+                                MediaType {
+                                    schema: Some(ReferenceOr::Reference {
+                                        reference: "#/components/schemas/schema_1".to_string(),
+                                    }),
+                                    ..Default::default()
+                                },
+                            )]),
+                            ..Default::default()
+                        }),
+                    ),
+                ]),
+                schemas: IndexMap::from([
+                    (
+                        "schema_1".to_string(),
+                        ReferenceOr::Reference {
+                            reference: "#/components/schemas/schema_2".to_string(),
+                        },
+                    ),
+                    (
+                        "schema_2".to_string(),
+                        ReferenceOr::Item(Schema {
+                            schema_data: SchemaData {
+                                title: Some("schema_2".to_string()),
+                                ..Default::default()
+                            },
+                            schema_kind: SchemaKind::Type(Type::String(StringType {
+                                ..Default::default()
+                            })),
+                        }),
+                    ),
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let path: &PathItem = openapi
+            .paths
+            .paths
+            .get("/")
+            .expect("able to get path")
+            .as_item()
+            .expect("able to resolve path");
+
+        let get = path.get.as_ref().expect("expect to be able to get 'get'");
+        let reponse_200 = get
+            .responses
+            .responses
+            .get(&StatusCode::Code(200))
+            .expect("able to get response 200");
+
+        let content_json = reponse_200
+            .resolve(&openapi)
+            .expect("able to resolve response 200")
+            .content
+            .get("application/json")
+            .expect("able to get content");
+
+        let schema = content_json
+            .schema
+            .as_ref()
+            .expect("able to get schema")
+            .resolve(&openapi)
+            .expect("able to resolve schema");
+
+        assert_eq!(schema.schema_data.title.as_ref().unwrap(), "schema_2");
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -26,7 +26,28 @@ where
     }
 }
 
+impl<T> ResolveWithOpenAPI<T> for ReferenceOr<Box<T>>
+where
+    OpenAPI: Resolve<T>,
+{
+    fn resolve<'a>(&'a self, openapi: &'a OpenAPI) -> Option<&'a T> {
+        match self {
+            ReferenceOr::Reference { reference } => openapi.resolve(reference),
+            ReferenceOr::Item(item) => Some(item),
+        }
+    }
+}
+
 impl<T> ResolveWithOpenAPI<T> for Option<ReferenceOr<T>>
+where
+    OpenAPI: Resolve<T>,
+{
+    fn resolve<'a>(&'a self, openapi: &'a OpenAPI) -> Option<&'a T> {
+        self.as_ref()?.resolve(openapi)
+    }
+}
+
+impl<T> ResolveWithOpenAPI<T> for Option<ReferenceOr<Box<T>>>
 where
     OpenAPI: Resolve<T>,
 {


### PR DESCRIPTION
# Add resolve helpers for ReferenceOr

## What's this?

Makes it easier to get the value of a reference. Whether you have an inline value or a `$ref` pointing to `#/components/`, just call `.resolve(&openapi)` and get back a `&T`.

## Example

```rust
let resp = op.responses.responses.get(&StatusCode::Code(200)).unwrap();
let resolved_resp = resp.resolve(&openapi).unwrap();

let mt = resolved_resp.content.get("application/json").unwrap();
let schema = mt.schema.resolve(&openapi).unwrap();
// schema is the fully resolved Schema, whether it was inline or a $ref
```

Works with `ReferenceOr<T>`, `ReferenceOr<Box<T>>`, and `Option<ReferenceOr<T>>`.

Also added some iteration helpers like `OpenAPI::operations()` and `PathItem::iter()` while I was at it.

No breaking changes, everything's backward compatible.
