### PR TITLE
schema: IntegerKind: multiple_of: change type to unsigned

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -245,7 +245,7 @@ impl<'de> Deserialize<'de> for SchemaKind {
             {
                 Ok(Self::Type(Type::Integer(IntegerType {
                     format: format.into(),
-                    multiple_of: multiple_of.map(|v| v.as_i64().unwrap()),
+                    multiple_of: multiple_of.map(|v| v.as_u64().unwrap()),
                     exclusive_minimum: exclusive_minimum.unwrap_or_default(),
                     exclusive_maximum: exclusive_maximum.unwrap_or_default(),
                     minimum: minimum.map(|v| v.as_i64().unwrap()),
@@ -681,7 +681,7 @@ pub struct IntegerType {
     #[serde(default, skip_serializing_if = "VariantOrUnknownOrEmpty::is_empty")]
     pub format: VariantOrUnknownOrEmpty<IntegerFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub multiple_of: Option<i64>,
+    pub multiple_of: Option<u64>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub exclusive_minimum: bool,
     #[serde(default, skip_serializing_if = "is_false")]


### PR DESCRIPTION
Per the JSON Schema Specification, `multipleOf` must be strictly greater than 0, and <= 0 is an invalid value.

Reference:
<https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.1>

OAS 3.0.4 makes no adjustment to this keyword.

Reference:
<https://spec.openapis.org/oas/v3.0.4.html#x4-7-24-1-json-schema-keywords>

Note that changing the type to `Option<u64>` is insufficient to guarantee a parsing error upon an invalid specification, using `NonZeroU64` will uphold this completely. If you prefer that change instead, I'm happy to adjust this PR.