### PR TITLE
schema: preserve None for all enumeration fields

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -539,12 +539,12 @@ fn none_or_int(value: &Option<serde_json::Number>) -> bool {
 fn enumerated_values_transform<T, F>(
     enumeration: Option<Vec<serde_json::Value>>,
     transform: F,
-) -> Vec<Option<T>>
+) -> Option<Vec<Option<T>>>
 where
     F: Fn(&serde_json::Value) -> Option<T>,
 {
-    match enumeration {
-        Some(values) => values
+    enumeration.map(|values| {
+        values
             .iter()
             .map(|v| {
                 if v.is_null() {
@@ -553,9 +553,8 @@ where
                     Some(transform(v).unwrap())
                 }
             })
-            .collect::<Vec<_>>(),
-        None => Default::default(),
-    }
+            .collect::<Vec<_>>()
+    })
 }
 
 fn enumerated_values_valid<F>(enumeration: &Option<Vec<serde_json::Value>>, check: F) -> bool
@@ -648,8 +647,8 @@ pub struct StringType {
     pub format: VariantOrUnknownOrEmpty<StringFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enumeration: Vec<Option<String>>,
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub enumeration: Option<Vec<Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_length: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -671,8 +670,8 @@ pub struct NumberType {
     pub minimum: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<f64>,
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enumeration: Vec<Option<f64>>,
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub enumeration: Option<Vec<Option<f64>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -690,8 +689,8 @@ pub struct IntegerType {
     pub minimum: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<i64>,
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enumeration: Vec<Option<i64>>,
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub enumeration: Option<Vec<Option<i64>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -725,8 +724,8 @@ pub struct ArrayType {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BooleanType {
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enumeration: Vec<Option<bool>>,
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub enumeration: Option<Vec<Option<bool>>>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -914,7 +913,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
             })) => {
-                assert_eq!(enumeration, vec![None, Some("howdy".to_string())]);
+                assert_eq!(enumeration, Some(vec![None, Some("howdy".to_string())]));
             }
             _ => panic!("incorrect kind {:#?}", schema),
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -180,12 +180,12 @@ fn petstore_discriminated() {
                                             ..Default::default()
                                         },
                                         schema_kind: SchemaKind::Type(Type::String(StringType {
-                                            enumeration: vec![
+                                            enumeration: Some(vec![
                                                 Some("clueless".to_owned()),
                                                 Some("lazy".to_owned()),
                                                 Some("adventurous".to_owned()),
                                                 Some("aggressive".to_owned()),
-                                            ],
+                                            ]),
                                             ..Default::default()
                                         })),
                                     }),


### PR DESCRIPTION
This change preserves a distinction made by OAS,
between an uninhabited schema versus one without `enum` restriction.

Per the spec:

> This array SHOULD have at least one element.
> ...
>  An instance validates successfully against this keyword if its value
>  is equal to one of the elements in this keyword's array value.

Reference:
<https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.20>

This implies that if the keyword `enum` is omitted, the schema imposes no enumeration constraint. Conversely, if the keyword is present but its array is empty, the schema is uninhabited, as no instance can satisfy an empty enumeration.

OAS 3.0.4 does not change the interpretation of this keyword. Reference:
<https://spec.openapis.org/oas/v3.0.4.html#x4-7-24-1-json-schema-keywords>